### PR TITLE
fix(frontend): use backend service for api base

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,8 +11,10 @@ RUN npm ci
 # Kopiuj resztę kodu frontendu
 COPY . .
 
-# W produkcyjnym kontenerze frontend łączy się z usługą backend
-ENV VITE_API_BASE="http://localhost:8000"
+# W produkcyjnym kontenerze frontend łączy się z usługą backend.
+# Używamy nazwy usługi Docker Compose, aby zapewnić prawidłową komunikację
+# między kontenerami, gdy aplikacja jest uruchomiona w środowisku produkcyjnym.
+ENV VITE_API_BASE="http://backend:8000"
 
 # Zbuduj aplikację (plik wyjściowy w /app/dist)
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure production frontend uses the backend service hostname

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890e137705c8323883bdbfeee08ea66