### PR TITLE
feat: add binance crypto portfolio tab

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from services.price_service import PriceService
 
 # Make price_service globally available
 price_service = PriceService()
-from routers import categories, incomes, expenses, investments, savings, ai, prices
+from routers import categories, incomes, expenses, investments, savings, ai, prices, crypto
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -70,6 +70,7 @@ app.include_router(investments.router, prefix="/api", tags=["investments"])
 app.include_router(savings.router, prefix="/api", tags=["savings"])
 app.include_router(ai.router, prefix="/api", tags=["ai"])
 app.include_router(prices.router, prefix="/api", tags=["prices"])
+app.include_router(crypto.router, prefix="/api", tags=["crypto"])
 
 # Health check endpoint
 @app.get("/", tags=["health"])

--- a/backend/routers/crypto.py
+++ b/backend/routers/crypto.py
@@ -1,0 +1,71 @@
+"""Crypto router for fetching Binance balances"""
+import os
+import time
+import hmac
+import hashlib
+from typing import List, Dict, Any
+
+import requests
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+BINANCE_API_URL = "https://api.binance.com"
+
+
+def _sign_query(query: str, secret_key: str) -> str:
+    return hmac.new(secret_key.encode(), query.encode(), hashlib.sha256).hexdigest()
+
+
+@router.get("/crypto/binance")
+def get_binance_balances() -> Dict[str, Any]:
+    """Return spot balances from Binance with 24h profit/loss."""
+    api_key = os.getenv("BINANCE_API_KEY")
+    secret_key = os.getenv("BINANCE_SECRET_KEY")
+    if not api_key or not secret_key:
+        raise HTTPException(status_code=500, detail="Binance API credentials not configured")
+
+    timestamp = int(time.time() * 1000)
+    query = f"timestamp={timestamp}"
+    signature = _sign_query(query, secret_key)
+
+    headers = {"X-MBX-APIKEY": api_key}
+    account_res = requests.get(
+        f"{BINANCE_API_URL}/api/v3/account",
+        params={"timestamp": timestamp, "signature": signature},
+        headers=headers,
+        timeout=10,
+    )
+    account_res.raise_for_status()
+    account = account_res.json()
+
+    balances: List[Dict[str, Any]] = []
+    for bal in account.get("balances", []):
+        total = float(bal.get("free", 0)) + float(bal.get("locked", 0))
+        if total <= 0:
+            continue
+        asset = bal["asset"]
+        symbol = f"{asset}USDT"
+        ticker_res = requests.get(
+            f"{BINANCE_API_URL}/api/v3/ticker/24hr",
+            params={"symbol": symbol},
+            timeout=10,
+        )
+        if ticker_res.status_code != 200:
+            price = 0.0
+            change = 0.0
+        else:
+            tdata = ticker_res.json()
+            price = float(tdata.get("lastPrice", 0))
+            change = float(tdata.get("priceChange", 0))
+        value = total * price
+        pnl_24h = change * total
+        balances.append({
+            "asset": asset,
+            "quantity": total,
+            "price": price,
+            "value": value,
+            "pnl_24h": pnl_24h,
+        })
+
+    return {"balances": balances}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ExpensesPage from './pages/ExpensesPage';
 import SavingsPage from './pages/SavingsPage';
 import SummaryPage from './pages/SummaryPage';
 import InvestmentsPage from './pages/InvestmentsPage';
+import CryptoPage from './pages/CryptoPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
           <Route path="/savings" element={<SavingsPage />} />
           <Route path="/summary" element={<SummaryPage />} />
           <Route path="/investments" element={<InvestmentsPage />} />
+          <Route path="/crypto" element={<CryptoPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { Settings, CreditCard, PiggyBank, TrendingUp, PieChart } from 'lucide-react';
+import { Settings, CreditCard, PiggyBank, TrendingUp, PieChart, Coins } from 'lucide-react';
 
 const tabs = [
   { id: 'admin', label: 'Admin/Budżet', icon: Settings, path: '/admin' },
@@ -7,6 +7,7 @@ const tabs = [
   { id: 'savings', label: 'Cele Oszczędnościowe', icon: PiggyBank, path: '/savings' },
   { id: 'summary', label: 'Podsumowanie', icon: TrendingUp, path: '/summary' },
   { id: 'investments', label: 'Inwestycje', icon: PieChart, path: '/investments' },
+  { id: 'crypto', label: 'Krypto', icon: Coins, path: '/crypto' },
 ];
 
 export default function Navigation() {

--- a/frontend/src/pages/CryptoPage.tsx
+++ b/frontend/src/pages/CryptoPage.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface BinanceBalance {
+  asset: string;
+  quantity: number;
+  price: number;
+  value: number;
+  pnl_24h: number;
+}
+
+export default function CryptoPage() {
+  const { data, isLoading, error } = useQuery<{ balances: BinanceBalance[] }>({
+    queryKey: ['/api/crypto/binance'],
+  });
+
+  if (isLoading) {
+    return <div className="p-8">Ładowanie...</div>;
+  }
+
+  if (error) {
+    return <div className="p-8 text-red-600">Błąd wczytywania danych</div>;
+  }
+
+  const balances = data?.balances || [];
+  const totalValue = balances.reduce((sum, b) => sum + b.value, 0);
+  const totalPnl = balances.reduce((sum, b) => sum + b.pnl_24h, 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Portfel krypto (Binance)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b">
+                <th className="py-2 text-left">Aktywo</th>
+                <th className="py-2 text-right">Ilość</th>
+                <th className="py-2 text-right">Cena [USDT]</th>
+                <th className="py-2 text-right">Wartość [USDT]</th>
+                <th className="py-2 text-right">Zysk/Strata 24h [USDT]</th>
+              </tr>
+            </thead>
+            <tbody>
+              {balances.map(b => (
+                <tr key={b.asset} className="border-b last:border-b-0">
+                  <td className="py-2">{b.asset}</td>
+                  <td className="py-2 text-right">{b.quantity.toFixed(8)}</td>
+                  <td className="py-2 text-right">{b.price.toFixed(2)}</td>
+                  <td className="py-2 text-right">{b.value.toFixed(2)}</td>
+                  <td
+                    className={`py-2 text-right ${b.pnl_24h >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                  >
+                    {b.pnl_24h >= 0 ? '+' : ''}{b.pnl_24h.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+              <tr className="font-bold">
+                <td className="py-2">Suma</td>
+                <td></td>
+                <td></td>
+                <td className="py-2 text-right">{totalValue.toFixed(2)}</td>
+                <td
+                  className={`py-2 text-right ${totalPnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                >
+                  {totalPnl >= 0 ? '+' : ''}{totalPnl.toFixed(2)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add FastAPI router to fetch Binance balances and compute 24h PnL
- add "Krypto" tab and page to display Binance portfolio in frontend
- wire new crypto router and navigation entry

## Testing
- `cd backend && pytest`
- `cd ../frontend && npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f1abaa2883238bfee6c03817c3c7