### PR TITLE
feat: add binance crypto portfolio tab

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from services.price_service import PriceService
 
 # Make price_service globally available
 price_service = PriceService()
-from routers import categories, incomes, expenses, investments, savings, ai, prices
+from routers import categories, incomes, expenses, investments, savings, ai, prices, crypto
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -70,6 +70,7 @@ app.include_router(investments.router, prefix="/api", tags=["investments"])
 app.include_router(savings.router, prefix="/api", tags=["savings"])
 app.include_router(ai.router, prefix="/api", tags=["ai"])
 app.include_router(prices.router, prefix="/api", tags=["prices"])
+app.include_router(crypto.router, prefix="/api", tags=["crypto"])
 
 # Health check endpoint
 @app.get("/", tags=["health"])

--- a/backend/routers/crypto.py
+++ b/backend/routers/crypto.py
@@ -1,0 +1,120 @@
+"""Crypto router for fetching Binance data"""
+
+import os
+import time
+import hmac
+import hashlib
+from typing import List, Dict, Any
+
+import requests
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+BINANCE_API_URL = "https://api.binance.com"
+
+
+def _sign_query(query: str, secret_key: str) -> str:
+    return hmac.new(secret_key.encode(), query.encode(), hashlib.sha256).hexdigest()
+
+
+def _get_usdt_to_pln_rate() -> float:
+    """Fetch current USDT to PLN conversion rate."""
+    try:
+        res = requests.get(
+            f"{BINANCE_API_URL}/api/v3/ticker/price",
+            params={"symbol": "USDTPLN"},
+            timeout=10,
+        )
+        res.raise_for_status()
+        return float(res.json().get("price", 0))
+    except Exception:
+        return 0.0
+
+
+@router.get("/crypto/binance")
+def get_binance_balances() -> Dict[str, Any]:
+    """Return spot balances from Binance with 24h profit/loss in USDT and PLN."""
+    api_key = os.getenv("BINANCE_API_KEY")
+    secret_key = os.getenv("BINANCE_SECRET_KEY")
+    if not api_key or not secret_key:
+        raise HTTPException(status_code=500, detail="Binance API credentials not configured")
+
+    timestamp = int(time.time() * 1000)
+    query = f"timestamp={timestamp}"
+    signature = _sign_query(query, secret_key)
+
+    headers = {"X-MBX-APIKEY": api_key}
+    account_res = requests.get(
+        f"{BINANCE_API_URL}/api/v3/account",
+        params={"timestamp": timestamp, "signature": signature},
+        headers=headers,
+        timeout=10,
+    )
+    account_res.raise_for_status()
+    account = account_res.json()
+
+    usdt_pln = _get_usdt_to_pln_rate()
+
+    balances: List[Dict[str, Any]] = []
+    for bal in account.get("balances", []):
+        total = float(bal.get("free", 0)) + float(bal.get("locked", 0))
+        if total <= 0:
+            continue
+        asset = bal["asset"]
+        symbol = f"{asset}USDT"
+        ticker_res = requests.get(
+            f"{BINANCE_API_URL}/api/v3/ticker/24hr",
+            params={"symbol": symbol},
+            timeout=10,
+        )
+        if ticker_res.status_code != 200:
+            price = 0.0
+            change = 0.0
+        else:
+            tdata = ticker_res.json()
+            price = float(tdata.get("lastPrice", 0))
+            change = float(tdata.get("priceChange", 0))
+        value = total * price
+        pnl_24h = change * total
+        balances.append(
+            {
+                "asset": asset,
+                "quantity": total,
+                "price": price,
+                "value": value,
+                "pnl_24h": pnl_24h,
+                "price_pln": price * usdt_pln,
+                "value_pln": value * usdt_pln,
+                "pnl_24h_pln": pnl_24h * usdt_pln,
+            }
+        )
+
+    return {"balances": balances, "usdt_pln": usdt_pln}
+
+
+@router.get("/crypto/binance/klines/{symbol}")
+def get_binance_klines(symbol: str, interval: str = "1h", limit: int = 168) -> Dict[str, Any]:
+    """Return candlestick data for a symbol."""
+    try:
+        res = requests.get(
+            f"{BINANCE_API_URL}/api/v3/klines",
+            params={"symbol": symbol, "interval": interval, "limit": limit},
+            timeout=10,
+        )
+        res.raise_for_status()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    data = res.json()
+    klines = [
+        {
+            "open_time": k[0],
+            "open": float(k[1]),
+            "high": float(k[2]),
+            "low": float(k[3]),
+            "close": float(k[4]),
+        }
+        for k in data
+    ]
+    return {"klines": klines}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ExpensesPage from './pages/ExpensesPage';
 import SavingsPage from './pages/SavingsPage';
 import SummaryPage from './pages/SummaryPage';
 import InvestmentsPage from './pages/InvestmentsPage';
+import CryptoPage from './pages/CryptoPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
           <Route path="/savings" element={<SavingsPage />} />
           <Route path="/summary" element={<SummaryPage />} />
           <Route path="/investments" element={<InvestmentsPage />} />
+          <Route path="/crypto" element={<CryptoPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>

--- a/frontend/src/components/crypto/candlestick-chart.tsx
+++ b/frontend/src/components/crypto/candlestick-chart.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+interface CandleData {
+  time: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+interface Props {
+  data: CandleData[];
+}
+
+export default function CandlestickChart({ data }: Props) {
+  const width = data.length * 10 + 40;
+  const height = 300;
+  if (data.length === 0) {
+    return <div className="flex items-center justify-center h-full text-gray-500">Brak danych</div>;
+  }
+
+  const min = Math.min(...data.map(d => d.low));
+  const max = Math.max(...data.map(d => d.high));
+  const yScale = (price: number) => {
+    const padding = 10;
+    return height - ((price - min) / (max - min)) * (height - padding * 2) - padding;
+  };
+
+  return (
+    <svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`}>
+      {data.map((d, i) => {
+        const x = 20 + i * 10;
+        const openY = yScale(d.open);
+        const closeY = yScale(d.close);
+        const highY = yScale(d.high);
+        const lowY = yScale(d.low);
+        const color = d.close >= d.open ? '#16a34a' : '#dc2626';
+        return (
+          <g key={i}>
+            <line x1={x} x2={x} y1={highY} y2={lowY} stroke={color} strokeWidth={1} />
+            <rect
+              x={x - 3}
+              y={Math.min(openY, closeY)}
+              width={6}
+              height={Math.max(Math.abs(closeY - openY), 1)}
+              fill={color}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/src/components/crypto/pnl-chart.tsx
+++ b/frontend/src/components/crypto/pnl-chart.tsx
@@ -1,0 +1,20 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+
+interface ProfitPoint {
+  time: string;
+  value: number;
+}
+
+export default function ProfitLossHistoryChart({ data }: { data: ProfitPoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+        <XAxis dataKey="time" stroke="#666" fontSize={12} tick={{ fill: '#666' }} />
+        <YAxis stroke="#666" fontSize={12} tick={{ fill: '#666' }} tickFormatter={(v) => `${v.toFixed(0)} zł`} />
+        <Tooltip formatter={(v: any) => [`${Number(v).toFixed(2)} zł`, 'PnL']} />
+        <Line type="monotone" dataKey="value" stroke="#2563eb" strokeWidth={2} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { Settings, CreditCard, PiggyBank, TrendingUp, PieChart } from 'lucide-react';
+import { Settings, CreditCard, PiggyBank, TrendingUp, PieChart, Coins } from 'lucide-react';
 
 const tabs = [
   { id: 'admin', label: 'Admin/Budżet', icon: Settings, path: '/admin' },
@@ -7,6 +7,7 @@ const tabs = [
   { id: 'savings', label: 'Cele Oszczędnościowe', icon: PiggyBank, path: '/savings' },
   { id: 'summary', label: 'Podsumowanie', icon: TrendingUp, path: '/summary' },
   { id: 'investments', label: 'Inwestycje', icon: PieChart, path: '/investments' },
+  { id: 'crypto', label: 'Krypto', icon: Coins, path: '/crypto' },
 ];
 
 export default function Navigation() {

--- a/frontend/src/pages/CryptoPage.tsx
+++ b/frontend/src/pages/CryptoPage.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import CandlestickChart from '@/components/crypto/candlestick-chart';
+import ProfitLossHistoryChart from '@/components/crypto/pnl-chart';
+
+interface BinanceBalance {
+  asset: string;
+  quantity: number;
+  price: number;
+  value: number;
+  pnl_24h: number;
+  price_pln: number;
+  value_pln: number;
+  pnl_24h_pln: number;
+}
+
+interface Kline {
+  open_time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export default function CryptoPage() {
+  const { data, isLoading, error } = useQuery<{ balances: BinanceBalance[]; usdt_pln: number }>({
+    queryKey: ['/api/crypto/binance'],
+  });
+
+  const [selectedAsset, setSelectedAsset] = useState<string | undefined>();
+
+  const { data: klinesData } = useQuery<{ klines: Kline[] }>({
+    queryKey: ['/api/crypto/binance/klines', selectedAsset ? `${selectedAsset}USDT` : ''],
+    enabled: !!selectedAsset,
+  });
+
+  if (isLoading) {
+    return <div className="p-8">Ładowanie...</div>;
+  }
+
+  if (error) {
+    return <div className="p-8 text-red-600">Błąd wczytywania danych</div>;
+  }
+
+  const balances = data?.balances || [];
+  const totalValue = balances.reduce((sum, b) => sum + b.value_pln, 0);
+  const totalPnl = balances.reduce((sum, b) => sum + b.pnl_24h_pln, 0);
+
+  const candleData =
+    klinesData?.klines.map(k => ({
+      time: new Date(k.open_time).toLocaleString('pl-PL', {
+        hour: '2-digit',
+        day: '2-digit',
+        month: '2-digit',
+      }),
+      ...k,
+    })) || [];
+
+  const quantity = balances.find(b => b.asset === selectedAsset)?.quantity || 0;
+  const rate = data?.usdt_pln || 0;
+  const baseClose = candleData[0]?.close || 0;
+  const profitHistory = candleData.map(c => ({
+    time: c.time,
+    value: (c.close - baseClose) * quantity * rate,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Portfel krypto (Binance)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b">
+                <th className="py-2 text-left">Aktywo</th>
+                <th className="py-2 text-right">Ilość</th>
+                <th className="py-2 text-right">Cena [PLN]</th>
+                <th className="py-2 text-right">Wartość [PLN]</th>
+                <th className="py-2 text-right">Zysk/Strata 24h [PLN]</th>
+              </tr>
+            </thead>
+            <tbody>
+              {balances.map(b => (
+                <tr key={b.asset} className="border-b last:border-b-0">
+                  <td className="py-2">{b.asset}</td>
+                  <td className="py-2 text-right">{b.quantity.toFixed(8)}</td>
+                  <td className="py-2 text-right">{b.price_pln.toFixed(2)}</td>
+                  <td className="py-2 text-right">{b.value_pln.toFixed(2)}</td>
+                  <td
+                    className={`py-2 text-right ${b.pnl_24h_pln >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                  >
+                    {b.pnl_24h_pln >= 0 ? '+' : ''}{b.pnl_24h_pln.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+              <tr className="font-bold">
+                <td className="py-2">Suma</td>
+                <td></td>
+                <td></td>
+                <td className="py-2 text-right">{totalValue.toFixed(2)}</td>
+                <td className={`py-2 text-right ${totalPnl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{totalPnl >= 0 ? '+' : ''}{totalPnl.toFixed(2)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {balances.length > 0 && (
+          <div className="mt-6 space-y-6">
+            <div>
+              <select
+                className="border p-2 rounded"
+                value={selectedAsset}
+                onChange={e => setSelectedAsset(e.target.value)}
+              >
+                <option value="" disabled>
+                  Wybierz aktywo
+                </option>
+                {balances.map(b => (
+                  <option key={b.asset} value={b.asset}>
+                    {b.asset}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {candleData.length > 0 && (
+              <div className="h-80">
+                <CandlestickChart data={candleData} />
+              </div>
+            )}
+
+            {profitHistory.length > 0 && (
+              <div className="h-64">
+                <ProfitLossHistoryChart data={profitHistory} />
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add FastAPI router to fetch Binance balances and compute 24h PnL
- add "Krypto" tab and page to display Binance portfolio in frontend
- wire new crypto router and navigation entry

## Testing
- `cd backend && pytest`
- `cd ../frontend && npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f1abaa2883238bfee6c03817c3c7