### PR TITLE
Track monthly savings transfers

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -55,7 +55,7 @@ def init_db():
     """Initialize database tables"""
     try:
         # Import all models to ensure they are registered
-        from models import Category, Income, Expense, Investment, SavingsGoal
+        from models import Category, Income, Expense, Investment, SavingsGoal, SavingsTransaction
         
         # Create all tables
         Base.metadata.create_all(bind=engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,9 +1,10 @@
 """
 SQLAlchemy database models
 """
-from sqlalchemy import Column, String, DateTime, Boolean, Text, Integer
+from sqlalchemy import Column, String, DateTime, Boolean, Text, Integer, ForeignKey
 from sqlalchemy.types import DECIMAL
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
 from datetime import datetime
 import uuid
 from database import Base
@@ -62,3 +63,15 @@ class SavingsGoal(Base):
     color = Column(String(7), nullable=False)  # Hex color code
     is_completed = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class SavingsTransaction(Base):
+    __tablename__ = "savings_transactions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    savings_goal_id = Column(UUID(as_uuid=True), ForeignKey("savings_goals.id"), nullable=False)
+    amount = Column(DECIMAL(10, 2), nullable=False)
+    date = Column(String(10), nullable=False)  # YYYY-MM-DD format
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    goal = relationship("SavingsGoal", backref="transactions")

--- a/backend/routers/savings.py
+++ b/backend/routers/savings.py
@@ -4,10 +4,17 @@ Savings Goals API router
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from datetime import datetime
 
 from database import get_db
-from models import SavingsGoal
-from schemas import SavingsGoalCreate, SavingsGoalUpdate, SavingsGoal as SavingsGoalSchema, AddSavingsRequest
+from models import SavingsGoal, SavingsTransaction
+from schemas import (
+    SavingsGoalCreate,
+    SavingsGoalUpdate,
+    SavingsGoal as SavingsGoalSchema,
+    AddSavingsRequest,
+    SavingsTransaction as SavingsTransactionSchema,
+)
 
 router = APIRouter()
 
@@ -64,20 +71,51 @@ def add_savings(goal_id: str, request: AddSavingsRequest, db: Session = Depends(
     db_goal = db.query(SavingsGoal).filter(SavingsGoal.id == goal_id).first()
     if not db_goal:
         raise HTTPException(status_code=404, detail="Savings goal not found")
-    
+
     db_goal.current_amount = float(db_goal.current_amount) + float(request.amount)
-    
+
+    # Record savings transaction
+    transaction = SavingsTransaction(
+        savings_goal_id=goal_id,
+        amount=request.amount,
+        date=datetime.utcnow().strftime("%Y-%m-%d"),
+    )
+    db.add(transaction)
+
     # Check if goal is completed
     if float(db_goal.current_amount) >= float(db_goal.target_amount):
         db_goal.is_completed = True
-    
+
     db.commit()
     db.refresh(db_goal)
     return db_goal
 
-@router.get("/savings-transactions/{year}/{month}")
+@router.get("/savings-transactions/{year}/{month}", response_model=List[SavingsTransactionSchema])
 def get_savings_transactions(year: int, month: int, db: Session = Depends(get_db)):
-    """Get savings transactions for a specific month (placeholder)"""
-    # This endpoint exists for compatibility with frontend
-    # Savings transactions functionality can be implemented later
-    return []
+    """Get savings transactions for a specific month"""
+    start_date = f"{year:04d}-{month:02d}-01"
+    end_month = month + 1
+    end_year = year
+    if end_month > 12:
+        end_month = 1
+        end_year += 1
+    end_date = f"{end_year:04d}-{end_month:02d}-01"
+
+    transactions = (
+        db.query(SavingsTransaction)
+        .join(SavingsGoal)
+        .filter(SavingsTransaction.date >= start_date, SavingsTransaction.date < end_date)
+        .all()
+    )
+
+    return [
+        {
+            "id": tx.id,
+            "savings_goal_id": tx.savings_goal_id,
+            "goal_title": tx.goal.title if tx.goal else "",
+            "amount": tx.amount,
+            "date": tx.date,
+            "created_at": tx.created_at,
+        }
+        for tx in transactions
+    ]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -135,6 +135,15 @@ class SavingsGoal(SavingsGoalBase):
 class AddSavingsRequest(CamelModel):
     amount: Decimal = Field(..., gt=0, description="Amount to add to savings goal")
 
+
+class SavingsTransaction(CamelModel):
+    id: UUID
+    savings_goal_id: UUID
+    goal_title: str
+    amount: Decimal
+    date: str
+    created_at: datetime
+
 # AI and analysis schemas
 class RiskAnalysisResponse(CamelModel):
     var_95: float

--- a/frontend/src/pages/SummaryPage.tsx
+++ b/frontend/src/pages/SummaryPage.tsx
@@ -104,15 +104,12 @@ export default function SummaryPage() {
               <div>
                 <p className="text-sm text-muted-foreground">Oszczędności</p>
                 <p className="text-2xl font-bold">{savings.toFixed(2)} zł</p>
-                {totalSavingsAdded > 0 && (
-                  <p className="text-xs text-orange-500">
-                    -{totalSavingsAdded.toFixed(2)} zł przeznaczono do celów
-                  </p>
-                )}
                 {savingsTransactions.length > 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    {savingsTransactions.length} transakcji oszczędnościowych
-                  </p>
+                  savingsTransactions.map(tx => (
+                    <p key={tx.id} className="text-xs text-orange-500">
+                      -{parseFloat(tx.amount).toFixed(2)} zł na {tx.goalTitle}
+                    </p>
+                  ))
                 )}
               </div>
               <div className="bg-purple-100 p-3 rounded-full">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -91,6 +91,7 @@ export interface SavingsGoal {
 export interface SavingsTransaction {
   id: string;
   savingsGoalId: string;
+  goalTitle: string;
   amount: string;
   date: string;
   createdAt?: string;


### PR DESCRIPTION
## Summary
- record each savings transfer with a new `SavingsTransaction` model and API endpoint
- display monthly savings goal contributions on the summary card

## Testing
- `pytest` *(no tests found)*
- `npm test` *(missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890fba6387c8323bd5f399e5aaa8193